### PR TITLE
Create mentee

### DIFF
--- a/app/controllers/api/v1/mentees_controller.rb
+++ b/app/controllers/api/v1/mentees_controller.rb
@@ -1,0 +1,28 @@
+class Api::V1::MentorsController < ApplicationController
+  def create
+    mentee = User.new_mentee(mentee_params)
+    if mentor.save
+      User.create_mentee_info(mentee_params, mentee)
+      render json: MenteeSerializer.new(mentee), status: 200
+    else
+      render json: { message: "incorrect user information supplied"}, status: 400
+    end
+  end
+
+  private
+
+  def mentee_params
+    params.permit(
+    :background,
+    :cohort,
+    :program,
+    :email,
+    :first_name,
+    :last_name,
+    :phone,
+    :slack,
+    :identities => [],
+    :availability => {}
+  )
+  end
+end

--- a/app/controllers/api/v1/mentees_controller.rb
+++ b/app/controllers/api/v1/mentees_controller.rb
@@ -1,7 +1,7 @@
-class Api::V1::MentorsController < ApplicationController
+class Api::V1::MenteesController < ApplicationController
   def create
     mentee = User.new_mentee(mentee_params)
-    if mentor.save
+    if mentee.save
       User.create_mentee_info(mentee_params, mentee)
       render json: MenteeSerializer.new(mentee), status: 200
     else

--- a/app/controllers/api/v1/mentors_controller.rb
+++ b/app/controllers/api/v1/mentors_controller.rb
@@ -1,14 +1,14 @@
 class Api::V1::MentorsController < ApplicationController
   def index
     mentors = User.get_mentors_by_location_and_tech_skills(params)
-    render json: UserSerializer.new(mentors), status: 200
+    render json: MentorSerializer.new(mentors), status: 200
   end
 
   def create
     mentor = User.new_mentor(mentor_params)
     if mentor.save
       User.create_mentor_info(mentor_params, mentor)
-      render json: UserSerializer.new(mentor), status: 200
+      render json: MentorSerializer.new(mentor), status: 200
     else
       render json: { message: "incorrect user information supplied"}, status: 400
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,6 +86,12 @@ class User < ApplicationRecord
     new(mentor_attributes)
   end
 
+  def self.create_mentee_info(mentee_params, mentee)
+    ContactDetails.for_user(mentee_params, mentee)
+    UserIdentity.for_user(mentee_params[:identities].map(&:to_i), mentee)
+    Availability.for_user(mentee_params[:availability], mentee)
+  end
+
   def self.create_mentor_info(mentor_params, mentor)
     ContactDetails.for_user(mentor_params, mentor)
     UserIdentity.for_user(mentor_params[:identities].map(&:to_i), mentor)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,6 +60,18 @@ class User < ApplicationRecord
     return User.remote_mentors if location_param == "remote"
   end
 
+  def self.new_mentee(attributes)
+    mentee_attributes = {
+      first_name: attributes[:first_name],
+      last_name: attributes[:last_name],
+      cohort: attributes[:cohort],
+      program: attributes[:program],
+      background: attributes[:background],
+      mentor: false
+    }
+    new(mentee_attributes)
+  end
+
   def self.new_mentor(attributes)
     mentor_attributes = {
       first_name: attributes[:first_name],

--- a/app/serializers/mentee_serializer.rb
+++ b/app/serializers/mentee_serializer.rb
@@ -1,0 +1,13 @@
+class MenteeSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :first_name, :last_name, :cohort, :program, :background, :mentor
+  attribute :availability do |user|
+    user.list_availability
+  end
+  attribute :identities do |user|
+    user.list_identities
+  end
+  attribute :contact_details do |user|
+    user.list_contact_details
+  end
+end

--- a/app/serializers/mentor_serializer.rb
+++ b/app/serializers/mentor_serializer.rb
@@ -1,4 +1,4 @@
-class UserSerializer
+class MentorSerializer
   include FastJsonapi::ObjectSerializer
   attributes :first_name, :last_name, :cohort, :program, :current_job, :background, :mentor, :location
   attribute :tech_skills do |user|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get '/mentors', to: 'mentors#index'
       post '/mentors', to: 'mentors#create'
+      post '/mentees', to: 'mentees#create'
     end
   end
 end
- 

--- a/spec/requests/get_mentors_spec.rb
+++ b/spec/requests/get_mentors_spec.rb
@@ -41,7 +41,7 @@ describe 'GET /mentors', type: :request do
 
         mentor_json.each do |json|
           expect(json).to have_key("id")
-          expect(json["type"]).to eq("user")
+          expect(json["type"]).to eq("mentor")
           expect(json["attributes"]).to have_key("first_name")
           expect(json["attributes"]).to have_key("last_name")
           expect(json["attributes"]).to have_key("cohort")

--- a/spec/requests/post_mentee_spec.rb
+++ b/spec/requests/post_mentee_spec.rb
@@ -65,7 +65,7 @@ describe 'POST /mentees', type: :request do
 
       expect(User.count).to eq(1)
       expect(ContactDetails.count).to eq(1)
-      expect(UserIdentity.count).to eq(1)
+      expect(UserIdentity.count).to eq(3)
       expect(Availability.count).to eq(7)
     end
 

--- a/spec/requests/post_mentee_spec.rb
+++ b/spec/requests/post_mentee_spec.rb
@@ -30,18 +30,15 @@ describe 'POST /mentees', type: :request do
   context 'passing all neccesary attributes' do
     it 'returns the created mentee' do
       expect(User.count).to eq(0)
-      post '/api/v1/mentee', params: @user
+      post '/api/v1/mentees', params: @user
 
       identities = Identity.where(id: @user[:identities]).pluck(:title)
       created_user = JSON.parse(response.body)["data"]["attributes"]
-
       expect(created_user["first_name"]).to eq(@user[:first_name])
       expect(created_user["last_name"]).to eq(@user[:last_name])
       expect(created_user["cohort"]).to eq(@user[:cohort])
       expect(created_user["program"]).to eq(@user[:program])
-      expect(created_user["current_job"]).to eq("student")
       expect(created_user["background"]).to eq(@user[:background])
-      expect(created_user["location"]).to eq("Denver, CO")
       expect(created_user["mentor"]).to be_falsey
       expect(created_user["identities"]).to eq(identities)
       expect(created_user["contact_details"]).to eq({
@@ -64,7 +61,7 @@ describe 'POST /mentees', type: :request do
 
     xit 'creates neccesary rows in supporting tables for the created user' do
       expect(User.count).to eq(0)
-      post '/api/v1/mentors', params: @user
+      post '/api/v1/mentees', params: @user
 
       expect(User.count).to eq(1)
       expect(ContactDetails.count).to eq(1)

--- a/spec/requests/post_mentee_spec.rb
+++ b/spec/requests/post_mentee_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+describe 'POST /mentees', type: :request do
+  before :each do
+    Identity.create(title: 'male')
+    Identity.create(title: 'parent')
+    Identity.create(title: 'BOSS')
+    @user = {
+      background: "...",
+      cohort: 1810,
+      program: "BE",
+      location: 'TAHITI',
+      email: "j@mail.com",
+      first_name: "j",
+      identities: [1, 2, 3],
+      last_name: "l",
+      phone: "720",
+      slack: "@slack",
+      availability: {
+        0 => [true, false, true],
+        1 => true,
+        2 => [true, false, false],
+        3 => [true, false, true],
+        4 => [false, false, true],
+        5 => [true, false, true],
+        6 => [true, false, false]
+      }
+    }
+  end
+
+  context 'passing all neccesary attributes' do
+    it 'returns the created mentee' do
+      expect(User.count).to eq(0)
+      post '/api/v1/mentee', params: @user
+
+      identities = Identity.where(id: @user[:identities]).pluck(:title)
+      created_user = JSON.parse(response.body)["data"]["attributes"]
+
+      expect(created_user["first_name"]).to eq(@user[:first_name])
+      expect(created_user["last_name"]).to eq(@user[:last_name])
+      expect(created_user["cohort"]).to eq(@user[:cohort])
+      expect(created_user["program"]).to eq(@user[:program])
+      expect(created_user["current_job"]).to eq("student")
+      expect(created_user["background"]).to eq(@user[:background])
+      expect(created_user["location"]).to eq("Denver, CO")
+      expect(created_user["mentor"]).to be_falsey
+      expect(created_user["identities"]).to eq(identities)
+      expect(created_user["contact_details"]).to eq({
+        "email" => @user[:email],
+        "phone" => @user[:phone],
+        "slack" => @user[:slack]
+      })
+      expect(created_user["availability"]).to eq({
+        "0" => @user[:availability][0],
+        "1" => [true,true,true],
+        "2" => @user[:availability][2],
+        "3" => @user[:availability][3],
+        "4" => @user[:availability][4],
+        "5" => @user[:availability][5],
+        "6" => @user[:availability][6]
+      })
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+    end
+
+    xit 'creates neccesary rows in supporting tables for the created user' do
+      expect(User.count).to eq(0)
+      post '/api/v1/mentors', params: @user
+
+      expect(User.count).to eq(1)
+      expect(ContactDetails.count).to eq(1)
+      expect(UserIdentity.count).to eq(1)
+      expect(Availability.count).to eq(7)
+    end
+
+    it 'returns error if not all user params are sent' do
+      user = {
+        background: "...",
+        cohort: 1810,
+        program: "BE",
+        current_job: "Ibotta",
+        email: "j@mail.com",
+        first_name: "j",
+      }
+
+      post '/api/v1/mentees', params: user
+
+      expect(response.status).to eq(400)
+      expect(response).to_not be_successful
+      expect(JSON.parse(response.body)).to eq({"message" => "incorrect user information supplied"})
+    end
+  end
+end

--- a/spec/requests/post_mentee_spec.rb
+++ b/spec/requests/post_mentee_spec.rb
@@ -9,7 +9,6 @@ describe 'POST /mentees', type: :request do
       background: "...",
       cohort: 1810,
       program: "BE",
-      location: 'TAHITI',
       email: "j@mail.com",
       first_name: "j",
       identities: [1, 2, 3],


### PR DESCRIPTION
## Creating a Mentee

Very similar to creating a Mentor

Adds
* POST route
* Mentees controller with create method and `mentee_params` which has less permitted parameters then it's mentor equivalent
* Mentee serializer which has less attributes (renamed User one to MentorSerializer)
* `new_mentee` and `create_mentee_info` methods 
